### PR TITLE
indy node update 1.12.4 -> 1.12.5

### DIFF
--- a/build/Dockerfile.bullseye
+++ b/build/Dockerfile.bullseye
@@ -32,9 +32,9 @@ RUN apt-get update -y && \
 #    libsodium18 \
 #    libindy-crypto=0.4.5 \
 #    python3-indy-crypto=0.4.5 \
-    indy-node=1.12.4 \
+    indy-node=1.12.5 \
     # node depends on plenum
-    indy-plenum=1.12.4 \
+    indy-plenum=1.12.5 \
     #plenum dependencies
     python3-ujson=1.33-1build1 \
     python3-prompt-toolkit=0.57-1 \

--- a/build/Dockerfile.buster
+++ b/build/Dockerfile.buster
@@ -32,9 +32,9 @@ RUN apt-get update -y && \
 #    libsodium18 \
 #    libindy-crypto=0.4.5 \
 #    python3-indy-crypto=0.4.5 \
-    indy-node=1.12.4 \
+    indy-node=1.12.5 \
     # node depends on plenum
-    indy-plenum=1.12.4 \
+    indy-plenum=1.12.5 \
     #plenum dependencies
     python3-ujson=1.33-1build1 \
     python3-prompt-toolkit=0.57-1 \

--- a/build/Dockerfile.ubuntu16
+++ b/build/Dockerfile.ubuntu16
@@ -14,8 +14,8 @@ RUN apt-get update -y && apt-get install -y \
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88
 RUN bash -c 'echo "deb https://repo.sovrin.org/deb xenial stable" >> /etc/apt/sources.list'
 RUN apt-get update -y && apt-get install -y \
-    indy-node=1.12.4 \
-    indy-plenum=1.12.4 \
+    indy-node=1.12.5 \
+    indy-plenum=1.12.5 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY init_and_run.sh ./

--- a/build/Dockerfile.ubuntu18
+++ b/build/Dockerfile.ubuntu18
@@ -31,9 +31,9 @@ RUN apt-get update -y && \
 #    libsodium18 \
 #    libindy-crypto=0.4.5 \
 #    python3-indy-crypto=0.4.5 \
-    indy-node=1.12.4 \
+    indy-node=1.12.5 \
     # node depends on plenum
-    indy-plenum=1.12.4 \
+    indy-plenum=1.12.5 \
     #plenum dependencies
     python3-ujson=1.33-1build1 \
     python3-prompt-toolkit=0.57-1 \


### PR DESCRIPTION
only the images using 1.12.4 are being updated, the ubuntu20 image still has the experimental rc release with a known bug in the state hashes. -> not touching this one for now.