### PR TITLE
restore image build on tag (i.e. release)

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -18,7 +18,6 @@ jobs:
     outputs:
       repo_owner: ${{ steps.repo_owner.outputs.lowercase }}
       os_matrix: "{\"os_version\":[\"debian10\",\"debian11\",\"ubuntu16\",\"ubuntu18\",\"ubuntu20\"]}"
-      testsNeeded: ${{ steps.testsNeeded.outputs.testsNeeded }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -26,19 +25,11 @@ jobs:
         id: repo_owner
         run: echo "lowercase=$(echo ${{ github.repository_owner }} | tr \"[:upper:]\" \"[:lower:]\")" >>$GITHUB_OUTPUT
         shell: bash
-      - name: testsNeeded
-        id: testsNeeded
-        uses: dorny/paths-filter@v2
-        with:
-          filters: |
-            testsNeeded:
-              - '!**.md'
 
   build_nodes:
     name: Build node images
     runs-on: ubuntu-latest
     needs: workflow_setup
-    if: ${{ needs.workflow_setup.outputs.testsNeeded == 'true' }}
     strategy:
       matrix: ${{ fromJson(needs.workflow_setup.outputs.os_matrix) }}
     steps:
@@ -83,7 +74,6 @@ jobs:
     name: Build controller image
     runs-on: ubuntu-latest
     needs: workflow_setup
-    if: ${{ needs.workflow_setup.outputs.testsNeeded == 'true' }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -120,7 +110,6 @@ jobs:
   test_node_and_controller:
     runs-on: ubuntu-latest
     needs: [workflow_setup, build_controller, build_nodes]
-    if: ${{ needs.workflow_setup.outputs.testsNeeded == 'true' }}
     strategy:
       matrix: ${{ fromJson(needs.workflow_setup.outputs.os_matrix) }}
       fail-fast: false
@@ -199,7 +188,7 @@ jobs:
     name: statusCheck
     runs-on: ubuntu-latest
     needs: [workflow_setup, test_node_and_controller]
-    if: ${{ needs.workflow_setup.outputs.testsNeeded == 'false' || success() }}
+    if: ${{ success() }}
     steps:
       - run: 'echo "Just a status Check (Always true, when executed) for branch protection rules(blocks merging while test are running and if tests fail)." '
 


### PR DESCRIPTION
removing 'tests needed' check that skips container builds for tag runs