### PR TITLE
Check iptables persistent with dpkg

### DIFF
--- a/run/ip_tables_utils.sh
+++ b/run/ip_tables_utils.sh
@@ -46,7 +46,7 @@ ip_tables_installed() {
 }
 
 ip_tables_persistent_installed() {
-    if which iptables-save 2>/dev/null 1>&2; then
+    if dpkg-query -W --showformat='${Status}' iptables-persistent | grep "install ok installed" 2>/dev/null 1>&2; then
         return 0
     fi
     return 1


### PR DESCRIPTION
The command iptables-save is part of the iptables package and NOT of the iptables-persistent package.

So the currently existing check is not suited to verify the existance of the iptables-persistent package.

Merge after #138 