### PR TITLE
Adjust default log level to only log severity info and above

### DIFF
--- a/run/etc_indy/indy_config.py
+++ b/run/etc_indy/indy_config.py
@@ -24,7 +24,7 @@ REV_STRATEGY_USE_COMPAT_ORDERING=True
 
 ## Logging
 # 0 means everything
-logLevel = 1
+logLevel = 20
 
 # Enable/Disable stdout logging
 enableStdOutLogging = True


### PR DESCRIPTION
The default log level for normal operation should not be set to trace.

This can lead to strange behavior during normal operation as writing and compressing the log information takes additional cpu time.