### PR TITLE
Update repository references for Ursa

### DIFF
--- a/build/Dockerfile.debian11
+++ b/build/Dockerfile.debian11
@@ -3,7 +3,6 @@
 # Copyright 2021-2025 by all people listed in https://github.com/hyperledger/indy-node-container/blob/main/NOTICE , see
 # https://github.com/hyperledger/indy-node-container/blob/main/LICENSE for the license information.
 
-
 FROM python:3.8-slim-bullseye
 
 LABEL org.opencontainers.image.description="Debian 11 based image to run indy-node. See https://github.com/hyperledger/indy-node-container"
@@ -19,36 +18,29 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     gnupg2 \
     && apt-get autoremove -y
 
-RUN \
-    # Ubtuntu 16 + sovrin repos are needed for old plenum dependencies going back to libssl1.0.0
-    add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial universe" \
-    && add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial main" \
-    && add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial-security main" \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88 40976EAF437D05B5 3B4FE6ACC0B21F32 \
-    && add-apt-repository "deb https://repo.sovrin.org/deb xenial stable" \
-    # Hyperledger Artifactory for latest indy-node
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9692C00E657DDE61 \
-    && add-apt-repository "deb https://hyperledger.jfrog.io/artifactory/indy focal stable" \
+# Bionic-security for libssl1.0.0
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3B4FE6ACC0B21F32 \
+    && echo "deb http://security.ubuntu.com/ubuntu bionic-security main"  >> /etc/apt/sources.list
+
+# Hyperledger Artifactory
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9692C00E657DDE61 \
+    && echo "deb https://hyperledger.jfrog.io/artifactory/indy focal stable" >> /etc/apt/sources.list \
+    # For Ursa
+    && echo "deb https://hyperledger.jfrog.io/artifactory/indy bionic master" >> /etc/apt/sources.list \
     # Prioritize packages from hyperledger.jfrog.io
-#    && printf '%s\n%s\n%s\n' 'Package: *' 'Pin: origin hyperledger.jfrog.io' 'Pin-Priority: 1001' >> /etc/apt/preferences \
-    && apt-get update -y
+    && printf '%s\n%s\n%s\n' 'Package: *' 'Pin: origin hyperledger.jfrog.io' 'Pin-Priority: 1001' >> /etc/apt/preferences
 
+RUN pip3 install -U \
+    # Required by setup.py
+    'setuptools==50.3.2'
 
-RUN apt-get install -y --allow-downgrades \
-    indy-node=1.13.2 \
-    indy-plenum=1.13.1 \
-    ursa=0.3.2-1 \
-    python3-libnacl=1.6.1 \
-    python3-pympler=0.8 \
-    python3-sortedcontainers=1.5.7 \
-    python3-ujson=1.33 \
-    && apt-get autoremove -y \
-    && apt-get clean
-
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && \
+    apt-get install -y --allow-downgrades \
+    indy-node="1.13.2" && \
+    apt-get autoremove -y && \
+    apt-get clean
 
 ENV PYTHONPATH="/usr/local/lib/python3.8:/usr/local/lib/python3.8/dist-packages/:/usr/local/lib/python3.5/dist-packages/:/usr/local/lib/python3.9/dist-packages/"
-
 
 # use python 3.8
 RUN rm /usr/bin/python3 && ln -s /usr/local/bin/python3 /usr/bin/python3
@@ -56,15 +48,21 @@ RUN rm /usr/bin/python3 && ln -s /usr/local/bin/python3 /usr/bin/python3
 # find lib ursa
 RUN ln -s /usr/lib/ursa/libursa.so /usr/lib/libursa.so
 
-# missing python packages
-RUN pip install zipp six rocksdb
+# `sha3` is broken -> use `pysha3` instead
+RUN rm -rf /usr/local/lib/python3.8/dist-packages/*sha3*
 
+# needed for pip install pysha3
+RUN apt-get install -y gcc
+
+# missing python packages
+RUN pip install pysha3 zipp six rocksdb
 
 WORKDIR /home/indy
 
 COPY init_and_run.sh ./
 
-
 CMD ["./init_and_run.sh"]
 
 VOLUME ["/var/log/indy"]
+
+RUN rm -rf /var/lib/apt/lists/*

--- a/build/Dockerfile.debian12
+++ b/build/Dockerfile.debian12
@@ -3,7 +3,6 @@
 # Copyright 2021-2025 by all people listed in https://github.com/hyperledger/indy-node-container/blob/main/NOTICE , see
 # https://github.com/hyperledger/indy-node-container/blob/main/LICENSE for the license information.
 
-
 FROM python:3.8-slim-bookworm
 
 LABEL org.opencontainers.image.description="Debian 12 based image to run indy-node. See https://github.com/hyperledger/indy-node-container"
@@ -19,38 +18,29 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     gnupg2 \
     && apt-get autoremove -y
 
+# Bionic-security for libssl1.0.0
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3B4FE6ACC0B21F32 \
+    && echo "deb http://security.ubuntu.com/ubuntu bionic-security main"  >> /etc/apt/sources.list
 
-RUN \
-    # Ubtuntu 16 + sovrin repos are needed for old plenum dependencies going back to libssl1.0.0
-    add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial universe" \
-    && add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial main" \
-    && add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial-security main" \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88 40976EAF437D05B5 3B4FE6ACC0B21F32 \
-    && add-apt-repository "deb https://repo.sovrin.org/deb xenial stable" \
-    # Hyperledger Artifactory for latest indy-node
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9692C00E657DDE61 \
-    && add-apt-repository "deb https://hyperledger.jfrog.io/artifactory/indy focal stable" \
+# Hyperledger Artifactory
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9692C00E657DDE61 \
+    && echo "deb https://hyperledger.jfrog.io/artifactory/indy focal stable" >> /etc/apt/sources.list \
+    # For Ursa
+    && echo "deb https://hyperledger.jfrog.io/artifactory/indy bionic master" >> /etc/apt/sources.list \
     # Prioritize packages from hyperledger.jfrog.io
-#    && printf '%s\n%s\n%s\n' 'Package: *' 'Pin: origin hyperledger.jfrog.io' 'Pin-Priority: 1001' >> /etc/apt/preferences \
-    && apt-get update -y
+    && printf '%s\n%s\n%s\n' 'Package: *' 'Pin: origin hyperledger.jfrog.io' 'Pin-Priority: 1001' >> /etc/apt/preferences
 
+RUN pip3 install -U \
+    # Required by setup.py
+    'setuptools==50.3.2'
 
-RUN apt-get install -y --allow-downgrades \
-    indy-node=1.13.2 \
-    indy-plenum=1.13.1 \
-    ursa=0.3.2-1 \
-    python3-libnacl=1.6.1 \
-    python3-pympler=0.8 \
-    python3-sortedcontainers=1.5.7 \
-    python3-ujson=1.33 \
-    python3-importlib-metadata=3.10.1 \
-    python3-distro=1.7.0 \
-    && apt-get autoremove -y \
-    && apt-get clean
-
+RUN apt-get update -y && \
+    apt-get install -y --allow-downgrades \
+    indy-node="1.13.2" && \
+    apt-get autoremove -y && \
+    apt-get clean
 
 ENV PYTHONPATH="/usr/local/lib/python3.8:/usr/local/lib/python3.8/dist-packages/:/usr/local/lib/python3.8/site-packages/:/usr/local/lib/python3.11/dist-packages/"
-
 
 # use python 3.8
 RUN rm /usr/bin/python3 && ln -s /usr/local/bin/python3 /usr/bin/python3
@@ -67,11 +57,9 @@ RUN apt-get install -y gcc
 # missing python packages
 RUN pip install tz python-dateutil pysha3 zipp six rocksdb orderedset packaging prompt_toolkit
 
-
 WORKDIR /home/indy
 
 COPY init_and_run.sh ./
-
 
 CMD ["./init_and_run.sh"]
 

--- a/build/Dockerfile.ubuntu20
+++ b/build/Dockerfile.ubuntu20
@@ -27,9 +27,9 @@ RUN apt-get update -y \
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3B4FE6ACC0B21F32 \
     && echo "deb http://security.ubuntu.com/ubuntu bionic-security main"  >> /etc/apt/sources.list
 
-# Sovrin
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88 \
-    && bash -c 'echo "deb https://repo.sovrin.org/deb bionic master" >> /etc/apt/sources.list'
+# Hyperledger Indy Artifactory for Ursa (plenum dependency)
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9692C00E657DDE61 \
+    && bash -c 'echo "deb https://hyperledger.jfrog.io/artifactory/indy bionic master" >> /etc/apt/sources.list'
 
 # Hyperledger Artifactory
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9692C00E657DDE61 \

--- a/build/Dockerfile.ubuntu22
+++ b/build/Dockerfile.ubuntu22
@@ -33,7 +33,7 @@ RUN  apt-get update \
         software-properties-common \
         wget \
         zip
-        
+
 
 # Dependencies for the (meta) dependency debs of indy-node
 RUN apt-get update && \
@@ -53,9 +53,9 @@ RUN apt-get update && \
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3B4FE6ACC0B21F32 \
     && echo "deb http://security.ubuntu.com/ubuntu bionic-security main"  >> /etc/apt/sources.list
 
-# Sovrin for Ursa (plenum dependency)
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88 \
-    && bash -c 'echo "deb https://repo.sovrin.org/deb bionic master" >> /etc/apt/sources.list' \
+# Hyperledger Indy Artifactory for Ursa (plenum dependency)
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9692C00E657DDE61 \
+    && bash -c 'echo "deb https://hyperledger.jfrog.io/artifactory/indy bionic master" >> /etc/apt/sources.list' \
     && apt-get update \
     && apt-get install -y \
         ursa \

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,77 +1,40 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update -y && apt-get install -y \
     apt-transport-https \
     ca-certificates \
-    software-properties-common \
-    libsodium-dev \
-    libsecp256k1-dev \
-    libssl-dev \
-    liblzma-dev \
+    gnupg2 \
+    ## ToDo remove unused packages
+    libgflags-dev \
     libsnappy-dev \
-    liblz4-dev \
-    libbz2-dev \
     zlib1g-dev \
-    librocksdb-dev \
-    python3.5 \
+    libbz2-dev \
+    liblz4-dev \
+    libgflags-dev \
     python3-pip \
     docker.io
+
+# Bionic-security for libssl1.0.0
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3B4FE6ACC0B21F32 \
+    && echo "deb http://security.ubuntu.com/ubuntu bionic-security main"  >> /etc/apt/sources.list
+
+# Hyperledger Artifactory
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 9692C00E657DDE61 \
+    && echo "deb https://hyperledger.jfrog.io/artifactory/indy focal stable" >> /etc/apt/sources.list \
+    # For Ursa
+    && echo "deb https://hyperledger.jfrog.io/artifactory/indy bionic master" >> /etc/apt/sources.list \
+    # Prioritize packages from hyperledger.jfrog.io
+    && printf '%s\n%s\n%s\n' 'Package: *' 'Pin: origin hyperledger.jfrog.io' 'Pin-Priority: 1001' >> /etc/apt/preferences
+
 RUN pip3 install -U \
-    'pip<10.0.0' \
-    'setuptools<58.0'
+    # Required by setup.py
+    'setuptools==50.3.2'
 
-
-
-# get node 1.12.4 dependencies from Ubtuntu 16 + sovrin repos
-RUN \
-    add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial universe" && \
-    add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial main" && \
-    add-apt-repository "deb http://archive.ubuntu.com/ubuntu xenial-security main" && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CE7709D068DB5E88 && \
-    add-apt-repository "deb https://repo.sovrin.org/deb xenial stable" 
-
-    RUN apt-get update -y && \
-    apt-get install -y --allow-downgrades \
-#    libssl1.0.0 \
-#    libsodium18 \
-#    libindy-crypto=0.4.5 \
-#    python3-indy-crypto=0.4.5 \
-    indy-node=1.12.6 \
-    # node depends on plenum
-    indy-plenum=1.12.6 \
-    #plenum dependencies
-    python3-ujson=1.33-1build1 \
-    python3-prompt-toolkit=0.57-1 \
-    python3-pygments=2.2.0 \
-    python3-rlp=0.5.1 \
-    python3-sha3=0.2.1 \
-    python3-leveldb=0~svn68-2build4 \
-    python3-sortedcontainers=1.5.7 \
-    python3-pip=9.0.1-2 \
-    python3-portalocker=0.5.7 \
-    python3-libnacl=1.6.1 \
-    python3-six=1.11.0 \
-    python3-intervaltree=2.1.0 \
-    python3-msgpack=0.4.6-1build1 \
-    python3-rocksdb=0.6.9 \
-    python3-dateutil=2.6.1 \
-    # meta dependencies of those python packages
-    python3-setuptools=38.5.2 \
-    python-pip-whl=9.0.1-2 \
-    # plenum in particular depends on python 3.5
-    python3=3.5.1-3 \
-    python3-minimal=3.5.1-3 \
-    libpython3-stdlib=3.5.1-3 \
-    dh-python=2.20151103ubuntu1.2 \
-    #
-    && apt-get autoremove -y
-
-
-# https://podman.io/getting-started/installation#installing-on-linux
-# > CAUTION: The Kubic repo is NOT recommended for production use. 
-#RUN echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-#RUN apt-key adv --fetch-keys https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/Release.key
-#RUN apt-get update -y && apt-get install -y podman
+RUN apt-get update -y && apt-get install -y \
+    indy-node="1.13.2" \
+    && rm -rf /var/lib/apt/lists/* \
+    # fix path to libursa
+    && ln -s /usr/lib/ursa/libursa.so /usr/lib/libursa.so
 
 RUN mkdir /opt/controller
 
@@ -80,5 +43,10 @@ COPY upgrade_indy.sh /opt/controller/upgrade_indy
 COPY start_node_control_tool /opt/controller/start_node_control_tool
 COPY container_node_control_tool.py /opt/controller/container_node_control_tool.py
 COPY init_and_run.sh ./
+
+RUN chmod +x /opt/controller/restart_indy_node \
+             /opt/controller/upgrade_indy \
+             /opt/controller/start_node_control_tool \
+             ./init_and_run.sh
 
 CMD ["./init_and_run.sh"]


### PR DESCRIPTION
- The Ursa package has been migrated to the Hyperledger repository.  The Sovrin repositories have been deprecated.
  - New location: https://hyperledger.jfrog.io/ui/native/indy/pool/bionic/master/u/ursa/
  - Previous location: https://repo.sovrin.org/deb/pool/bionic/master/u/ursa/
- Clean up Dockerfiles
- Upgrade controller